### PR TITLE
[DRAFT] Initial implementation of Gmail agent. Not ready for real world use.

### DIFF
--- a/agents/gmail/.gitignore
+++ b/agents/gmail/.gitignore
@@ -1,0 +1,3 @@
+secret.txt
+credentials.json
+token.json

--- a/agents/gmail/.gitignore
+++ b/agents/gmail/.gitignore
@@ -1,3 +1,3 @@
-secret.txt
+openaikey.txt
 credentials.json
 token.json

--- a/agents/gmail/.gitignore
+++ b/agents/gmail/.gitignore
@@ -1,3 +1,4 @@
 openaikey.txt
 credentials.json
 token.json
+weaviatekey.txt

--- a/agents/gmail/agent.yaml
+++ b/agents/gmail/agent.yaml
@@ -1,0 +1,7 @@
+handle: "gmail"
+description: |
+  The `gmail` Agent answers questions based on the contents of a Gmail inbox.
+  Tags: func
+more_info_url: "https://github.com/fixie-ai/fixie-examples"
+entry_point: main:agent
+public: true

--- a/agents/gmail/main.py
+++ b/agents/gmail/main.py
@@ -1,0 +1,72 @@
+import random
+from typing import Optional
+from threading import Thread
+
+import fixieai
+from llama_index import GPTSimpleVectorIndex, download_loader
+
+import os
+
+BASE_PROMPT = """I'm an agent that answers questions about Gmail messages."""
+FEW_SHOTS = """
+Q: What are the next steps with Oana from SignalFire?
+Ask Func[question]: What are the next steps with Oana from SignalFire?
+Func[question] says: The next steps with Oana from SignalFire are to schedule a meeting for the week of March 20th.
+A: The next steps with Oana from SignalFire are to schedule a meeting for the week of March 20th.
+
+Q: What is Nick's start date?
+Ask Func[question]: What is Nick's start date?
+Func[question] says: Nick Heiner's start date is April 4.
+A: Nick Heiner's start date is April 4.
+"""
+agent = fixieai.CodeShotAgent(BASE_PROMPT, FEW_SHOTS)
+
+initializing = False
+ready = False
+status = "Initializing"
+index: Optional[GPTSimpleVectorIndex] = None
+
+
+def init() -> str:
+    global initializing, ready, status, index
+    if initializing:
+        return
+    try:
+        initializing = True
+        print("Initializing...")
+        status = "Initializing..."
+        with open("secret.txt") as f:
+            line = f.readline()
+            os.environ["OPENAI_API_KEY"] = line.strip()
+        print("Downloading GmailReader...")
+        status = "Downloading GmailReader..."
+        GmailReader = download_loader("GmailReader")
+        loader = GmailReader(query="label:inbox")
+        print("Loading data...")
+        status = "Loading data..."
+        documents = loader.load_data()
+        print("Building index...")
+        status = "Building index..."
+        index = GPTSimpleVectorIndex(documents)
+        print("Ready")
+        status = "Ready"
+        ready = True
+    except Exception as e:
+        print(e)
+        status = f"Gmail agent failed to initialize: {e}"
+        ready = False
+    finally:
+        initializing = False
+
+
+@agent.register_func
+def question(query: fixieai.Message, user_storage: fixieai.UserStorage) -> str:
+    print(f"Query: {query.text}")
+    if not ready:
+        if not initializing:
+            init_thread = Thread(target=init)
+            init_thread.start()
+        return f"I am sorry, I can't answer that question right now. I am still initializing. Status: {status}"
+    response = index.query(query.text)
+    print(f"Response: {response}")
+    return response.response

--- a/agents/gmail/requirements.txt
+++ b/agents/gmail/requirements.txt
@@ -1,0 +1,3 @@
+fixieai ~= 0.1.11
+llama-index ~= 0.4.26
+

--- a/agents/gmail/requirements.txt
+++ b/agents/gmail/requirements.txt
@@ -1,3 +1,4 @@
 fixieai ~= 0.1.11
 llama-index ~= 0.4.26
+weaviate-client ~= 3.15.3
 


### PR DESCRIPTION
This is a draft of an agent that uses LlamaIndex to index a user's Gmail inbox and answer questions about it. I would not consider this ready for real world use, due to the following caveat.

Unfortunately, the way LlamaIndex works is that it calls out internally to the Google OAuth library to get the user to authenticate with Gmail - but this is not hooked back into the Fixie query flow -- so there is essentially no way for someone to authenticate with Gmail on a deployed version of this agent. If you do run `fixie agent serve` locally, you can authenticate against the local version which writes the `token.json` file to the local directory which will be included in the deployed agent if you do `fixie agent deploy`. The problem with this is that the token is tied to the original person that ran `fixie agent serve` and hence the deployed agent, if made public, would only be able to access that user's inbox.
