### PR TITLE
Add Langchain search agent

### DIFF
--- a/agents/langchain_search/agent.yaml
+++ b/agents/langchain_search/agent.yaml
@@ -3,8 +3,8 @@ description: |
   A simple demo of search using Langchain's ReAct chain.
 
   Example queries:
-    - Who is Olivia Wilde's boyfriend, and what was his most recent album?
-    - What is the difference between OpenAI's GPT-4 and Facebook's LLAMA?
+    - Who is Olivia Wilde's boyfriend, and what is his current age raised to the 0.23 power?
+    - What is GPT-4, and what is its largest context size?
 
 more_info_url: https://github.com/fixie-ai/fixie-examples
 entry_point: main:agent

--- a/agents/langchain_search/agent.yaml
+++ b/agents/langchain_search/agent.yaml
@@ -1,5 +1,11 @@
 handle: langchain-search
-description: A simple demo of chat-zero-shot-react-description
-more_info_url: ''
+description: |
+  A simple demo of search using Langchain's ReAct chain.
+
+  Example queries:
+    - Who is Olivia Wilde's boyfriend, and what was his most recent album?
+    - What is the difference between OpenAI's GPT-4 and Facebook's LLAMA?
+
+more_info_url: https://github.com/fixie-ai/fixie-examples
 entry_point: main:agent
 public: false

--- a/agents/langchain_search/agent.yaml
+++ b/agents/langchain_search/agent.yaml
@@ -1,0 +1,5 @@
+handle: langchain-search
+description: A simple demo of chat-zero-shot-react-description
+more_info_url: ''
+entry_point: main:agent
+public: false

--- a/agents/langchain_search/main.py
+++ b/agents/langchain_search/main.py
@@ -1,19 +1,15 @@
-import os
+"""
+This agent demonstrates how to use langchain's zero-shot ReAct chain in a Fixie standalone agent.
+Standalone agents give the developer complete control over query processing, but you'll need to
+specify your OPENAI_API_KEY (and also SERPAPI_API_KEY) in a local .env file to use this agent.
+"""
 
 import fixieai
-import yaml
+
 from langchain.agents import initialize_agent
 from langchain.agents import load_tools
 from langchain.chat_models import ChatOpenAI
 from langchain.llms import OpenAI
-
-# Set up the agent in standalone mode.
-agent = fixieai.CodeShotAgent("", [])
-
-# Load the necessary API keys from the keys.yaml file.
-keys = yaml.load(open("keys.yaml"), Loader=yaml.FullLoader)
-for key in keys:
-    os.environ[key] = keys[key]
 
 
 def _run_executor(text: str) -> str:
@@ -27,9 +23,12 @@ def _run_executor(text: str) -> str:
     return executor.run(text)
 
 
-@agent.register_func
 def main(query: fixieai.Message) -> str:
     try:
         return _run_executor(query.text)
     except Exception as e:
         return "Failed: " + str(e)
+
+
+# Set up the agent as a StandaloneAgent, in which the agent does any LLM handling internally.
+agent = fixieai.StandaloneAgent(main)

--- a/agents/langchain_search/main.py
+++ b/agents/langchain_search/main.py
@@ -1,0 +1,35 @@
+import os
+
+import fixieai
+import yaml
+from langchain.agents import initialize_agent
+from langchain.agents import load_tools
+from langchain.chat_models import ChatOpenAI
+from langchain.llms import OpenAI
+
+# Set up the agent in standalone mode.
+agent = fixieai.CodeShotAgent("", [])
+
+# Load the necessary API keys from the keys.yaml file.
+keys = yaml.load(open("keys.yaml"), Loader=yaml.FullLoader)
+for key in keys:
+    os.environ[key] = keys[key]
+
+
+def _run_executor(text: str) -> str:
+    # as seen in https://github.com/hwchase17/langchain/blob/master/docs/getting_started/getting_started.md
+    chat = ChatOpenAI(temperature=0)
+    llm = OpenAI(temperature=0)
+    tools = load_tools(["serpapi", "llm-math"], llm=llm)
+    executor = initialize_agent(
+        tools, chat, agent="chat-zero-shot-react-description", verbose=True
+    )
+    return executor.run(text)
+
+
+@agent.register_func
+def main(query: fixieai.Message) -> str:
+    try:
+        return _run_executor(query.text)
+    except Exception as e:
+        return "Failed: " + str(e)

--- a/agents/langchain_search/requirements.txt
+++ b/agents/langchain_search/requirements.txt
@@ -1,4 +1,4 @@
-fixieai ~= 0.2.7
+fixieai ~= 0.2.10
 langchain ~= 0.0.123
 openai ~= 0.27.2
 google_search_results ~= 2.4.1

--- a/agents/langchain_search/requirements.txt
+++ b/agents/langchain_search/requirements.txt
@@ -1,0 +1,4 @@
+fixieai ~= 0.2.7
+langchain ~= 0.0.123
+openai ~= 0.27.2
+google_search_results ~= 2.4.1


### PR DESCRIPTION
Adapts the sample shown in https://github.com/hwchase17/langchain/blob/master/docs/getting_started/getting_started.md to run on Fixie as a standalone (non-few-shot) agent.